### PR TITLE
Decoupling total from scan

### DIFF
--- a/Checkout.Tests/CheckoutTests.cs
+++ b/Checkout.Tests/CheckoutTests.cs
@@ -37,7 +37,7 @@ public class CheckoutTests
         Assert.Equal(expectedTotal, checkout.Total);
     }
 
-    [Theory]
+    [Theory(Skip = "WIP Changing the design")]
     [InlineData(new[] { Item.A, Item.A }, 100)]
     [InlineData(new[] { Item.A, Item.A, Item.A }, 130)] //EligibleForSpecial A x1
     [InlineData(new[] { Item.A, Item.A, Item.A, Item.A }, 180)]
@@ -67,7 +67,7 @@ public class CheckoutTests
 
     // When I got to this point I found I can use the same rule structure to cover the 2 for 1 scenario
 
-    [Theory]
+    [Theory(Skip = "WIP Changing the design")]
     [InlineData(new[] { Item.A, Item.A, Item.A }, 100)]
     [InlineData(new[] { Item.B, Item.B, Item.B }, 60)]
     [InlineData(new[] { Item.C, Item.C, Item.C }, 40)]
@@ -92,7 +92,7 @@ public class CheckoutTests
     }
 
     // Scenario "1.99 per pound"
-    [Theory]
+    [Theory(Skip = "WIP Changing the design")]
     [InlineData(Item.A, 1, 1.99)]
     [InlineData(Item.A, 1.5, 2.98)] //Rounded to 2 decimal points
     [InlineData(Item.A, 2, 3.98)]

--- a/Checkout.Tests/CheckoutTests.cs
+++ b/Checkout.Tests/CheckoutTests.cs
@@ -37,7 +37,7 @@ public class CheckoutTests
         Assert.Equal(expectedTotal, checkout.Total);
     }
 
-    [Theory(Skip = "WIP Changing the design")]
+    [Theory]
     [InlineData(new[] { Item.A, Item.A }, 100)]
     [InlineData(new[] { Item.A, Item.A, Item.A }, 130)] //EligibleForSpecial A x1
     [InlineData(new[] { Item.A, Item.A, Item.A, Item.A }, 180)]

--- a/Checkout.Tests/CheckoutTests.cs
+++ b/Checkout.Tests/CheckoutTests.cs
@@ -92,7 +92,7 @@ public class CheckoutTests
     }
 
     // Scenario "1.99 per pound"
-    [Theory(Skip = "WIP Changing the design")]
+    [Theory]
     [InlineData(Item.A, 1, 1.99)]
     [InlineData(Item.A, 1.5, 2.98)] //Rounded to 2 decimal points
     [InlineData(Item.A, 2, 3.98)]

--- a/Checkout.Tests/CheckoutTests.cs
+++ b/Checkout.Tests/CheckoutTests.cs
@@ -67,7 +67,7 @@ public class CheckoutTests
 
     // When I got to this point I found I can use the same rule structure to cover the 2 for 1 scenario
 
-    [Theory(Skip = "WIP Changing the design")]
+    [Theory]
     [InlineData(new[] { Item.A, Item.A, Item.A }, 100)]
     [InlineData(new[] { Item.B, Item.B, Item.B }, 60)]
     [InlineData(new[] { Item.C, Item.C, Item.C }, 40)]

--- a/Checkout/Checkout.cs
+++ b/Checkout/Checkout.cs
@@ -24,8 +24,6 @@ public class Checkout
     {
         AddToScannedItems(item);
 
-
-
         //if (IsEligibleForDiscount(item))
         //    Total += GetDiscountedPrice(item);
         //else
@@ -47,19 +45,9 @@ public class Checkout
         {
 
             if (IsOnSpecial(item))
-            {
-                var unitPrice = _rules[item].UnitPrice;
-                var specialQty = _rules[item].Special!.Quantity;
-                var specialPrice = _rules[item].Special!.Price;
-
-                int specialCount = itemQty / specialQty;
-                var nonSpecialCount = itemQty % specialQty;
-
-                total += specialCount * specialPrice;
-                total += nonSpecialCount * unitPrice;
-            }
+                total += GetItemTotalWithSpecial(item, itemQty);
             else
-                total += itemQty * GetItemUnitPrice(item);
+                total += GetItemTotal(item, itemQty);
         }
 
         return total;
@@ -80,10 +68,22 @@ public class Checkout
 
         _scannedItemsWeight[item]+= weight;
     }
-
-    private double GetItemUnitPrice(Item item)
+    
+    private double GetItemTotalWithSpecial(Item item, int itemQty)
     {
-        return _rules[item].UnitPrice;
+        var unitPrice = _rules[item].UnitPrice;
+        var specialQty = _rules[item].Special!.Quantity;
+        var specialPrice = _rules[item].Special!.Price;
+
+        int specialCount = itemQty / specialQty;
+        var remainingCount = itemQty % specialQty;
+
+        return specialCount * specialPrice + remainingCount * unitPrice;
+    }
+
+    private double GetItemTotal(Item item, int itemQty)
+    {
+        return itemQty * _rules[item].UnitPrice;
     }
 
     //private bool IsEligibleForDiscount(Item item, int quantity)

--- a/Checkout/Checkout.cs
+++ b/Checkout/Checkout.cs
@@ -45,7 +45,21 @@ public class Checkout
 
         foreach (var (item, itemQty) in _scannedItemsCount)
         {
-            total += itemQty * GetItemUnitPrice(item);
+
+            if (IsOnSpecial(item))
+            {
+                var unitPrice = _rules[item].UnitPrice;
+                var specialQty = _rules[item].Special!.Quantity;
+                var specialPrice = _rules[item].Special!.Price;
+
+                int specialCount = itemQty / specialQty;
+                var nonSpecialCount = itemQty % specialQty;
+
+                total += specialCount * specialPrice;
+                total += nonSpecialCount * unitPrice;
+            }
+            else
+                total += itemQty * GetItemUnitPrice(item);
         }
 
         return total;
@@ -80,10 +94,10 @@ public class Checkout
     //    return itemQuantityMatchesSpecial;
     //}
 
-    //private bool IsOnSpecial(Item item)
-    //{
-    //    return _rules[item].Special != null;
-    //}
+    private bool IsOnSpecial(Item item)
+    {
+        return _rules[item].Special != null;
+    }
 
     //private double GetDiscountedPrice(Item item)
     //{

--- a/Checkout/Checkout.cs
+++ b/Checkout/Checkout.cs
@@ -4,11 +4,12 @@ namespace Checkout;
 
 public class Checkout
 {
-    public double Total { get; private set; }
+    public double Total => CalculateTotal();
 
     private readonly IDictionary<Item, ItemPrice> _rules;
 
-    private readonly IDictionary<Item, int> _scannedItemsCount;
+    private readonly IDictionary<Item, int> _scannedItemsCount;  //PricePerItem
+    private readonly IDictionary<Item, double> _scannedItemsWeight; //PricePerWeight
 
     private const int RoundingPrecision = 2;
 
@@ -16,28 +17,38 @@ public class Checkout
     {
         _rules = rules;
         _scannedItemsCount = new Dictionary<Item, int>();
+        _scannedItemsWeight = new Dictionary<Item, double>();
     }
 
     public void Scan(Item item)
     {
         AddToScannedItems(item);
 
-        if (EligibleForDiscount(item))
-            Total += GetDiscountedPrice(item);
-        else
-            Total += GetItemUnitPrice(item);
+
+
+        //if (IsEligibleForDiscount(item))
+        //    Total += GetDiscountedPrice(item);
+        //else
+        //    Total += GetItemUnitPrice(item);
     }
 
     public void Scan(Item item, double weight)
     {
-        Total += GetPriceForWeight(item, weight);
+        AddToScannedItems(item, weight);
+
+        //Total += GetPriceForWeight(item, weight);
     }
 
-    private double GetPriceForWeight(Item item, double weight)
+    private double CalculateTotal()
     {
-        var itemPrice = weight * GetItemUnitPrice(item);
-        var itemPriceRounded = Math.Round(itemPrice, RoundingPrecision);
-        return itemPriceRounded;
+        var total = 0d;
+
+        foreach (var (item, itemQty) in _scannedItemsCount)
+        {
+            total += itemQty * GetItemUnitPrice(item);
+        }
+
+        return total;
     }
 
     private void AddToScannedItems(Item item)
@@ -48,42 +59,53 @@ public class Checkout
         _scannedItemsCount[item]++;
     }
 
+    private void AddToScannedItems(Item item, double weight)
+    {
+        if (!_scannedItemsWeight.ContainsKey(item))
+            _scannedItemsWeight.Add(item, 0);
+
+        _scannedItemsWeight[item]+= weight;
+    }
+
     private double GetItemUnitPrice(Item item)
     {
         return _rules[item].UnitPrice;
     }
 
-    private bool EligibleForDiscount(Item item)
-    {
-        if (!ItemOnSpecial(item))
-            return false;
+    //private bool IsEligibleForDiscount(Item item, int quantity)
+    //{
+    //    var quantityEligibleForDiscount = _rules[item].Special!.Quantity;
+    //    var itemQuantityMatchesSpecial = quantity % quantityEligibleForDiscount == 0;
 
-        var scannedItemQuantity = _scannedItemsCount[item];
-        var quantityEligibleForDiscount = _rules[item].Special!.Quantity;
-        var itemQuantityMatchesSpecial = scannedItemQuantity % quantityEligibleForDiscount == 0;
+    //    return itemQuantityMatchesSpecial;
+    //}
 
-        return itemQuantityMatchesSpecial;
-    }
+    //private bool IsOnSpecial(Item item)
+    //{
+    //    return _rules[item].Special != null;
+    //}
 
-    private bool ItemOnSpecial(Item item)
-    {
-        return _rules[item].Special != null;
-    }
+    //private double GetDiscountedPrice(Item item)
+    //{
+    //    var specialPrice = GetItemsSpecialPrice(item);
 
-    private double GetDiscountedPrice(Item item)
-    {
-        var specialPrice = GetItemsSpecialPrice(item);
+    //    return -1 * GetPriceAccountedForInTotal(item) + specialPrice;
+    //}
 
-        return -1 * GetPriceAccountedForInTotal(item) + specialPrice;
-    }
+    //private double GetItemsSpecialPrice(Item item)
+    //{
+    //    return _rules[item].Special!.Price;
+    //}
 
-    private double GetItemsSpecialPrice(Item item)
-    {
-        return _rules[item].Special!.Price;
-    }
+    //private double GetPriceAccountedForInTotal(Item item)
+    //{
+    //    return _rules[item].UnitPrice * (_rules[item].Special!.Quantity - 1);
+    //}
 
-    private double GetPriceAccountedForInTotal(Item item)
-    {
-        return _rules[item].UnitPrice * (_rules[item].Special!.Quantity - 1);
-    }
+    //private double GetPriceForWeight(Item item, double weight)
+    //{
+    //    var itemPrice = weight * GetItemUnitPrice(item);
+    //    var itemPriceRounded = Math.Round(itemPrice, RoundingPrecision);
+    //    return itemPriceRounded;
+    //}
 }

--- a/Checkout/Checkout.cs
+++ b/Checkout/Checkout.cs
@@ -23,18 +23,11 @@ public class Checkout
     public void Scan(Item item)
     {
         AddToScannedItems(item);
-
-        //if (IsEligibleForDiscount(item))
-        //    Total += GetDiscountedPrice(item);
-        //else
-        //    Total += GetItemUnitPrice(item);
     }
 
     public void Scan(Item item, double weight)
     {
         AddToScannedItems(item, weight);
-
-        //Total += GetPriceForWeight(item, weight);
     }
 
     private double CalculateTotal()
@@ -43,11 +36,15 @@ public class Checkout
 
         foreach (var (item, itemQty) in _scannedItemsCount)
         {
-
             if (IsOnSpecial(item))
                 total += GetItemTotalWithSpecial(item, itemQty);
             else
                 total += GetItemTotal(item, itemQty);
+        }
+
+        foreach (var (item, itemWeight) in _scannedItemsWeight)
+        {
+            total += GetItemTotal(item, itemWeight);
         }
 
         return total;
@@ -86,40 +83,15 @@ public class Checkout
         return itemQty * _rules[item].UnitPrice;
     }
 
-    //private bool IsEligibleForDiscount(Item item, int quantity)
-    //{
-    //    var quantityEligibleForDiscount = _rules[item].Special!.Quantity;
-    //    var itemQuantityMatchesSpecial = quantity % quantityEligibleForDiscount == 0;
-
-    //    return itemQuantityMatchesSpecial;
-    //}
+    private double GetItemTotal(Item item, double itemWeight)
+    {
+        var itemPrice = itemWeight * _rules[item].UnitPrice;
+        var itemPriceRounded = Math.Round(itemPrice, RoundingPrecision);
+        return itemPriceRounded;
+    }
 
     private bool IsOnSpecial(Item item)
     {
         return _rules[item].Special != null;
     }
-
-    //private double GetDiscountedPrice(Item item)
-    //{
-    //    var specialPrice = GetItemsSpecialPrice(item);
-
-    //    return -1 * GetPriceAccountedForInTotal(item) + specialPrice;
-    //}
-
-    //private double GetItemsSpecialPrice(Item item)
-    //{
-    //    return _rules[item].Special!.Price;
-    //}
-
-    //private double GetPriceAccountedForInTotal(Item item)
-    //{
-    //    return _rules[item].UnitPrice * (_rules[item].Special!.Quantity - 1);
-    //}
-
-    //private double GetPriceForWeight(Item item, double weight)
-    //{
-    //    var itemPrice = weight * GetItemUnitPrice(item);
-    //    var itemPriceRounded = Math.Round(itemPrice, RoundingPrecision);
-    //    return itemPriceRounded;
-    //}
 }


### PR DESCRIPTION
## Description
I reached a point where I had implemented enough functionality that I could see the flaw in the design. 

This PR is for my branch where I changed the design of my core logic. 
To separate the concern of calculating the total out from scanning the items. 

It used to update the total in "real-time" for the newly scanned item and could have been considered "more performant". Now it recalculates the total going over all the items each time. A trade off between clean code and perceived performance. However performance would realistically not be a problem as the user is unlikely to scan enough items to properly test the data structures. 